### PR TITLE
Fix typo when importing unabbreviated bibstrings

### DIFF
--- a/README
+++ b/README
@@ -46,7 +46,7 @@ To choose the abbreviated (short) or unabbreviated (long) version of the
 bibliography strings, use one of these commands in your LaTeX file:
 
     \bibliography{plume-bib/bibstring-abbrev,...,plume-bib/crossrefs-abbrev}
-    \bibliography{plume/bib/bibstring-unabbrev,...,plume-bib/crossrefs}
+    \bibliography{plume-bib/bibstring-unabbrev,...,plume-bib/crossrefs}
 
 When using the bibliographies, add near the top of your LaTeX document:
 


### PR DESCRIPTION
Fix typo when importing unabbreviated bibstrings