### PR TITLE
Add citation for "A Syntactic Approach to Type Soundness"

### DIFF
--- a/types.bib
+++ b/types.bib
@@ -2337,6 +2337,15 @@
   pages =	 "162--173",
 }
 
+@article{Wright1994SATS,
+  author = "Andrew K. Wright and Matthias Felleisen",
+  title =  "A Syntactic Approach to Type Soundness",
+  journal =  "Information and Computation",
+  year = 1994,
+  volume = 115,
+  pages = "38--94",
+}
+
 @InCollection{NiNi99tes,
   author =       "F. Nielson and H. R. Nielson",
   title =        "Type and Effect Systems",


### PR DESCRIPTION
This is a citation we mentioned in the rebuttal for our paper that we might find useful for a revision.

[ACM link here](https://dl.acm.org/doi/10.1006/inco.1994.1093)